### PR TITLE
Removing reference to non-existent plugin

### DIFF
--- a/region.json
+++ b/region.json
@@ -38,7 +38,6 @@
     ],
     "pluginOrder": [
         "layer_selector",
-        "measure",
-        "nearshore_waves"
+        "measure"
     ]
 }


### PR DESCRIPTION
The inclusion of a non-existent plugin is raising an exception
in the GeositeFramework core. This is the supposed to happen.

Because we don't have the repos setup for plugins, I'm removing
the reference to this plugin so the CI job can build again. It
was agreed that this is more straightforward than sticking the
plugin somewhere.
